### PR TITLE
Fix the nighttime dimming effect for 2D cabs

### DIFF
--- a/Source/RunActivity/Content/CabShader.fx
+++ b/Source/RunActivity/Content/CabShader.fx
@@ -44,9 +44,9 @@ sampler ImageSampler = sampler_state
 
 struct PIXEL_INPUT
 {
-	//float2 Position  : VPOS;
-	float2 TexCoords : TEXCOORD0;
+	float4 Position  : SV_POSITION;
 	float4 Color     : COLOR0;
+	float2 TexCoords : TEXCOORD0;
 	float3 Normal    : NORMAL;
 };
 

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -226,8 +226,8 @@ namespace Orts.Viewer3D
     public class SharedMaterialManager
     {
         readonly Viewer Viewer;
-        Dictionary<string, Material> Materials = new Dictionary<string, Material>();
-        Dictionary<string, bool> MaterialMarks = new Dictionary<string, bool>();
+        IDictionary<(string, string, int, float, Effect), Material> Materials = new Dictionary<(string, string, int, float, Effect), Material>();
+        IDictionary<(string, string, int, float, Effect), bool> MaterialMarks = new Dictionary<(string, string, int, float, Effect), bool>();
 
         public readonly LightConeShader LightConeShader;
         public readonly LightGlowShader LightGlowShader;
@@ -285,28 +285,12 @@ namespace Orts.Viewer3D
 
         }
 
-        public Material Load(string materialName)
-        {
-            return Load(materialName, null, 0, 0);
-        }
-
-        public Material Load(string materialName, string textureName)
-        {
-            return Load(materialName, textureName, 0, 0);
-        }
-
-        public Material Load(string materialName, string textureName, int options)
-        {
-            return Load(materialName, textureName, options, 0);
-        }
-
-        public Material Load(string materialName, string textureName, int options, float mipMapBias)
+        public Material Load(string materialName, string textureName = null, int options = 0, float mipMapBias = 0f, Effect effect = null)
         {
             if (textureName != null)
                 textureName = textureName.ToLower();
 
-            var materialKey = String.Format("{0}:{1}:{2}:{3}", materialName, textureName, options, mipMapBias);
-
+            var materialKey = (materialName, textureName, options, mipMapBias, effect);
             if (!Materials.ContainsKey(materialKey))
             {
                 switch (materialName)
@@ -357,7 +341,7 @@ namespace Orts.Viewer3D
                         Materials[materialKey] = new MSTSSkyMaterial(Viewer);
                         break;
                     case "SpriteBatch":
-                        Materials[materialKey] = new SpriteBatchMaterial(Viewer);
+                        Materials[materialKey] = new SpriteBatchMaterial(Viewer, effect: effect);
                         break;
                     case "Terrain":
                         Materials[materialKey] = new TerrainMaterial(Viewer, textureName, SharedMaterialManager.MissingTexture);
@@ -386,22 +370,20 @@ namespace Orts.Viewer3D
        public bool LoadNightTextures()
         {
             int count = 0;
-            foreach (KeyValuePair<string, Material> materialPair in Materials)
+            var sceneryMaterials = Materials.Values.Where((material) => material is SceneryMaterial);
+            foreach (SceneryMaterial material in sceneryMaterials)
             {
-                 if (materialPair.Value is SceneryMaterial)
+                if (material.LoadNightTexture())
+                    count++;
+                if (count >= 20)
                 {
-                    var material = materialPair.Value as SceneryMaterial;
-                    if (material.LoadNightTexture()) count++;
-                     if (count >= 20)
-                     {
-                         count = 0;
-                         // retest if there is enough free memory left;
-                         var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
-                         if (remainingMemorySpace < 0)
-                         { 
-                             return false; // too bad, no more space, other night textures won't be loaded
-                         }
-                     }
+                    count = 0;
+                    // retest if there is enough free memory left;
+                    var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
+                    if (remainingMemorySpace < 0)
+                    {
+                        return false; // too bad, no more space, other night textures won't be loaded
+                    }
                 }
             }
             return true;
@@ -410,38 +392,41 @@ namespace Orts.Viewer3D
        public bool LoadDayTextures()
        {
            int count = 0;
-           foreach (KeyValuePair<string, Material> materialPair in Materials)
-           {
-               if (materialPair.Value is SceneryMaterial)
-               {
-                   var material = materialPair.Value as SceneryMaterial;
-                   if (material.LoadDayTexture()) count++;
-                   if (count >= 20)
-                   {
-                       count = 0;
-                       // retest if there is enough free memory left;
-                       var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
-                       if (remainingMemorySpace < 0)
-                       {
-                           return false; // too bad, no more space, other night textures won't be loaded
-                       }
-                   }
-               }
+            var sceneryMaterials = Materials.Values.Where((material) => material is SceneryMaterial);
+            foreach (SceneryMaterial material in sceneryMaterials)
+            {
+                if (material.LoadDayTexture())
+                    count++;
+                if (count >= 20)
+                {
+                    count = 0;
+                    // retest if there is enough free memory left;
+                    var remainingMemorySpace = Viewer.LoadMemoryThreshold - Viewer.HUDWindow.GetWorkingSetSize();
+                    if (remainingMemorySpace < 0)
+                    {
+                        return false; // too bad, no more space, other night textures won't be loaded
+                    }
+                }
            }
            return true;
        }
 
         public void Mark()
         {
-            MaterialMarks = new Dictionary<string, bool>(Materials.Count);
+            MaterialMarks.Clear();
             foreach (var path in Materials.Keys)
                 MaterialMarks.Add(path, false);
         }
 
         public void Mark(Material material)
         {
-            if (Materials.ContainsValue(material))
-                MaterialMarks[Materials.First(kvp => kvp.Value == material).Key] = true;
+            foreach (var path in from kvp in Materials
+                                 where kvp.Value == material
+                                 select kvp.Key)
+            {
+                MaterialMarks[path] = true;
+                break;
+            }
         }
 
         public void Sweep()
@@ -637,23 +622,25 @@ namespace Orts.Viewer3D
     {
         public readonly SpriteBatch SpriteBatch;
 
-        readonly BlendState BlendState = BlendState.NonPremultiplied;
+        private readonly BlendState BlendState = BlendState.NonPremultiplied;
+        private readonly Effect Effect;
 
-        public SpriteBatchMaterial(Viewer viewer)
+        public SpriteBatchMaterial(Viewer viewer, Effect effect = null)
             : base(viewer, null)
         {
             SpriteBatch = new SpriteBatch(Viewer.RenderProcess.GraphicsDevice);
+            Effect = effect;
         }
 
-        public SpriteBatchMaterial(Viewer viewer, BlendState blendState)
-            : this(viewer)
+        public SpriteBatchMaterial(Viewer viewer, BlendState blendState, Effect effect = null)
+            : this(viewer, effect: effect)
         {
             BlendState = blendState;
         }
 
         public override void SetState(GraphicsDevice graphicsDevice, Material previousMaterial)
         {
-            SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState);
+            SpriteBatch.Begin(SpriteSortMode.Deferred, BlendState, effect: Effect);
         }
 
         public override void ResetState(GraphicsDevice graphicsDevice)

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -624,8 +624,8 @@ namespace Orts.Viewer3D
     {
         public readonly SpriteBatch SpriteBatch;
 
-        private readonly BlendState BlendState = BlendState.NonPremultiplied;
-        private readonly Effect Effect;
+        readonly BlendState BlendState = BlendState.NonPremultiplied;
+        readonly Effect Effect;
 
         public SpriteBatchMaterial(Viewer viewer, Effect effect = null)
             : base(viewer, null)

--- a/Source/RunActivity/Viewer3D/Materials.cs
+++ b/Source/RunActivity/Viewer3D/Materials.cs
@@ -370,8 +370,9 @@ namespace Orts.Viewer3D
        public bool LoadNightTextures()
         {
             int count = 0;
-            var sceneryMaterials = Materials.Values.Where((material) => material is SceneryMaterial);
-            foreach (SceneryMaterial material in sceneryMaterials)
+            foreach (SceneryMaterial material in from material in Materials.Values
+                                                 where material is SceneryMaterial
+                                                 select material)
             {
                 if (material.LoadNightTexture())
                     count++;
@@ -392,8 +393,9 @@ namespace Orts.Viewer3D
        public bool LoadDayTextures()
        {
            int count = 0;
-            var sceneryMaterials = Materials.Values.Where((material) => material is SceneryMaterial);
-            foreach (SceneryMaterial material in sceneryMaterials)
+            foreach (SceneryMaterial material in from material in Materials.Values
+                                                 where material is SceneryMaterial
+                                                 select material)
             {
                 if (material.LoadDayTexture())
                     count++;

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1501,7 +1501,6 @@ namespace Orts.Viewer3D.RollingStock
             if (Shader != null)
             {
                 Shader.SetTextureData(Position.X, Position.Y, Texture.Width * ScaleToScreen, Texture.Height * ScaleToScreen);
-                Shader.CurrentTechnique.Passes[0].Apply();
             }
             ControlView.SpriteBatch.Draw(Texture, Position, null, Color.White, Rotation, Origin, ScaleToScreen, SpriteEffects.None, 0);
         }
@@ -1698,7 +1697,6 @@ namespace Orts.Viewer3D.RollingStock
             if (Shader != null)
             {
                 Shader.SetTextureData(DestinationRectangle.Left, DestinationRectangle.Top, DestinationRectangle.Width, DestinationRectangle.Height);
-                Shader.CurrentTechnique.Passes[0].Apply();
             }
             ControlView.SpriteBatch.Draw(Texture, DestinationRectangle, SourceRectangle, DrawColor);
         }
@@ -1789,7 +1787,6 @@ namespace Orts.Viewer3D.RollingStock
             if (Shader != null)
             {
                 Shader.SetTextureData(DestinationRectangle.Left, DestinationRectangle.Top, DestinationRectangle.Width, DestinationRectangle.Height);
-                Shader.CurrentTechnique.Passes[0].Apply();
             }
             ControlView.SpriteBatch.Draw(Texture, DestinationRectangle, SourceRectangle, Color.White);
         }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1049,7 +1049,6 @@ namespace Orts.Viewer3D.RollingStock
         public CabRenderer(Viewer viewer, MSTSLocomotive car)
         {
             //Sequence = RenderPrimitiveSequence.CabView;
-            _Sprite2DCabView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch");
             _Viewer = viewer;
             _Locomotive = car;
 
@@ -1173,6 +1172,7 @@ namespace Orts.Viewer3D.RollingStock
                     ExtendedCVF.TranslatedColor(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light2Color));
             }
 
+            _Sprite2DCabView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch", effect: _Shader);
             _PrevScreenSize = DisplaySize;
 
         }

--- a/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
+++ b/Source/RunActivity/Viewer3D/RollingStock/MSTSLocomotiveViewer.cs
@@ -1052,6 +1052,24 @@ namespace Orts.Viewer3D.RollingStock
             _Viewer = viewer;
             _Locomotive = car;
 
+            // _Viewer.DisplaySize intercepted to adjust cab view height
+            Point DisplaySize = _Viewer.DisplaySize;
+            DisplaySize.Y = _Viewer.CabHeightPixels;
+
+            _PrevScreenSize = DisplaySize;
+
+            // Use same shader for both front-facing and rear-facing cabs.
+            if (_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF != null)
+            {
+                _Shader = new CabShader(viewer.GraphicsDevice,
+                    ExtendedCVF.TranslatedPosition(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light1Position, DisplaySize),
+                    ExtendedCVF.TranslatedPosition(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light2Position, DisplaySize),
+                    ExtendedCVF.TranslatedColor(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light1Color),
+                    ExtendedCVF.TranslatedColor(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light2Color));
+            }
+
+            _Sprite2DCabView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch", effect: _Shader);
+
             #region Create Control renderers
             ControlMap = new Dictionary<int, CabViewControlRenderer>();
             int[] count = new int[256];//enough to hold all types, count the occurence of each type
@@ -1157,24 +1175,6 @@ namespace Orts.Viewer3D.RollingStock
             _Viewer.AdjustCabHeight(_Viewer.DisplaySize.X, _Viewer.DisplaySize.Y);
 
             _Viewer.CabCamera.ScreenChanged();
-
-            // _Viewer.DisplaySize intercepted to adjust cab view height
-            Point DisplaySize = _Viewer.DisplaySize;
-            DisplaySize.Y = _Viewer.CabHeightPixels;
-
-            // Use same shader for both front-facing and rear-facing cabs.
-            if (_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF != null)
-            {
-                _Shader = new CabShader(viewer.GraphicsDevice,
-                    ExtendedCVF.TranslatedPosition(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light1Position, DisplaySize),
-                    ExtendedCVF.TranslatedPosition(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light2Position, DisplaySize),
-                    ExtendedCVF.TranslatedColor(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light1Color),
-                    ExtendedCVF.TranslatedColor(_Locomotive.CabViewList[(int)CabViewType.Front].ExtendedCVF.Light2Color));
-            }
-
-            _Sprite2DCabView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch", effect: _Shader);
-            _PrevScreenSize = DisplaySize;
-
         }
 
         public CabRenderer(Viewer viewer, MSTSLocomotive car, CabViewFile CVFFile) //used by 3D cab as a refrence, thus many can be eliminated
@@ -1396,7 +1396,7 @@ namespace Orts.Viewer3D.RollingStock
             Control = control;
             Shader = shader;
 
-            ControlView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch");
+            ControlView = (SpriteBatchMaterial)viewer.MaterialManager.Load("SpriteBatch", effect: Shader);
 
             HasCabLightDirectory = CABTextureManager.LoadTextures(Viewer, Control.ACEFile);
         }


### PR DESCRIPTION
This PR's code is inspired by, but is not identical to, the fix already present in @csantucci's NewYear fork. The changes it includes are:

- Passes CabShader to the SpriteBatch.Begin() calls of the cab background, cab display, and cab control materials.
- Refactors the materials cache to use tuple instead of string keys. This allows us to index into the cache with shaders.
- Changes CabShader to use an output vertex format appropriate for Monogame ([courtesy of](http://www.elvastower.com/forums/index.php?/topic/30924-going-beyond-the-4-gb-of-memory/page__st__280__p__240217#entry240217) @perpetualKid).