### PR TITLE
Silence HLSL implicit conversion warnings

### DIFF
--- a/Source/RunActivity/Content/ParticleEmitterShader.fx
+++ b/Source/RunActivity/Content/ParticleEmitterShader.fx
@@ -123,7 +123,7 @@ VERTEX_OUTPUT VSParticles(in VERTEX_INPUT In)
 	Out.Position = mul(float4(In.StartPosition_StartTime.xyz, 1), worldViewProjection);
 	
 	Out.TexCoord = texCoords[vertIdx];
-	int texAtlasPosition = In.TileXY_Vertex_ID.w;
+	float texAtlasPosition = In.TileXY_Vertex_ID.w;
 	int atlasX = texAtlasPosition % 4;
 	int atlasY = texAtlasPosition / 4;
 	Out.TexCoord += float2(0.25f * atlasX, 0.25f * atlasY);

--- a/Source/RunActivity/Content/PopupWindow.fx
+++ b/Source/RunActivity/Content/PopupWindow.fx
@@ -101,16 +101,16 @@ float4 PSPopupWindowGlass(in VERTEX_OUTPUT In) : COLOR
 {
 	float4 Color = tex2D(WindowSampler, In.TexCoords_Pos.xy);
 	float Mask = tex2D(WindowSampler, In.TexCoords_Pos.xy + float2(0.5, 0.0)).r;
-	float3 ScreenColor = tex2D(ScreenSampler, In.TexCoords_Pos.zw);
-	float3 ScreenColor1 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x, +1 / ScreenSize.y));
-	float3 ScreenColor2 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x,  0 / ScreenSize.y));
-	float3 ScreenColor3 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x, -1 / ScreenSize.y));
-	float3 ScreenColor4 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x, +1 / ScreenSize.y));
-	float3 ScreenColor5 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x,  0 / ScreenSize.y));
-	float3 ScreenColor6 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x, -1 / ScreenSize.y));
-	float3 ScreenColor7 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x, +1 / ScreenSize.y));
-	float3 ScreenColor8 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x,  0 / ScreenSize.y));
-	float3 ScreenColor9 = tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x, -1 / ScreenSize.y));
+	float3 ScreenColor = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw);
+	float3 ScreenColor1 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x, +1 / ScreenSize.y));
+	float3 ScreenColor2 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x,  0 / ScreenSize.y));
+	float3 ScreenColor3 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(+1 / ScreenSize.x, -1 / ScreenSize.y));
+	float3 ScreenColor4 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x, +1 / ScreenSize.y));
+	float3 ScreenColor5 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x,  0 / ScreenSize.y));
+	float3 ScreenColor6 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2( 0 / ScreenSize.x, -1 / ScreenSize.y));
+	float3 ScreenColor7 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x, +1 / ScreenSize.y));
+	float3 ScreenColor8 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x,  0 / ScreenSize.y));
+	float3 ScreenColor9 = (float3)tex2D(ScreenSampler, In.TexCoords_Pos.zw + float2(-1 / ScreenSize.x, -1 / ScreenSize.y));
 	ScreenColor = lerp(ScreenColor, (22 * GlassColor + ScreenColor + ScreenColor1 + ScreenColor2 + ScreenColor3 + ScreenColor4 + ScreenColor5 + ScreenColor6 + ScreenColor7 + ScreenColor8 + ScreenColor9) / 32, Mask);
 	return float4(lerp(ScreenColor, Color.rgb, Color.a), 1);
 }

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -157,10 +157,10 @@ void _VSNormalProjection(in VERTEX_INPUT In, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
 	Out.Position = mul(In.Position, WorldViewProjection);
-	Out.RelPosition.xyz = mul(In.Position, World) - ViewerPos;
+	Out.RelPosition.xyz = mul(In.Position, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
 	Out.TexCoords.xy = In.TexCoords;
-	Out.Normal_Light.xyz = normalize(mul(In.Normal, World).xyz);
+	Out.Normal_Light.xyz = normalize(mul(In.Normal, (float3x3)World).xyz);
 	
 	// Normal lighting (range 0.0 - 1.0)
 	// Need to calc. here instead of _VSLightsAndShadows() to avoid calling it from VSForest(), where it has gone into pre-shader in Shaders.cs
@@ -170,7 +170,7 @@ void _VSNormalProjection(in VERTEX_INPUT In, inout VERTEX_OUTPUT Out)
 void _VSSignalProjection(uniform bool Glow, in VERTEX_INPUT_SIGNAL In, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
-	float3 relPos = mul(In.Position, World) - ViewerPos;
+	float3 relPos = (float3)mul(In.Position, World) - ViewerPos;
 	// Position 1.5cm in front of signal.
 	In.Position.z += 0.015;
 	if (Glow) {
@@ -195,7 +195,7 @@ void _VSTransferProjection(in VERTEX_INPUT_TRANSFER In, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
 	Out.Position = mul(In.Position, WorldViewProjection);
-	Out.RelPosition.xyz = mul(In.Position, World) - ViewerPos;
+	Out.RelPosition.xyz = mul(In.Position, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
 	Out.TexCoords.xy = In.TexCoords;
 	Out.Normal_Light.w = 1;
@@ -204,7 +204,7 @@ void _VSTransferProjection(in VERTEX_INPUT_TRANSFER In, inout VERTEX_OUTPUT Out)
 void _VSLightsAndShadows(uniform bool ShaderModel3, in float4 InPosition, inout VERTEX_OUTPUT Out)
 {
 	// Headlight lighting
-	Out.LightDir_Fog.xyz = mul(InPosition, World) - HeadlightPosition.xyz;
+	Out.LightDir_Fog.xyz = mul(InPosition, World).xyz - HeadlightPosition.xyz;
 
 	// Fog fading
 	Out.LightDir_Fog.w = (2.0 / (1.0 + exp(length(Out.Position.xyz) * Fog.a * -2.0))) - 1.0;
@@ -224,7 +224,7 @@ VERTEX_OUTPUT VSGeneral(uniform bool ShaderModel3, in VERTEX_INPUT In)
 	if (ShaderModel3) {
 		if (determinant(In.Instance) != 0) {
 			In.Position = mul(In.Position, transpose(In.Instance));
-			In.Normal = mul(In.Normal, transpose(In.Instance));
+			In.Normal = mul(In.Normal, (float3x3)transpose(In.Instance));
 		}
 	}
 
@@ -295,14 +295,14 @@ VERTEX_OUTPUT VSForest(in VERTEX_INPUT_FOREST In)
 	float3 upVector = float3(0, -1, 0); // This constant is also defined in Shareds.cs
 
 	// Move the vertex left/right/up/down based on the normal values (tree size).
-	float3 newPosition = In.Position;
+	float3 newPosition = (float3)In.Position;
 	newPosition += (In.TexCoords.x - 0.5f) * SideVector * In.Normal.x;
 	newPosition += (In.TexCoords.y - 1.0f) * upVector * In.Normal.y;
 	In.Position = float4(newPosition, 1);
 
 	// Project vertex with fixed w=1 and normal=eye.
 	Out.Position = mul(In.Position, WorldViewProjection);
-	Out.RelPosition.xyz = mul(In.Position, World) - ViewerPos;
+	Out.RelPosition.xyz = mul(In.Position, World).xyz - ViewerPos;
 	Out.RelPosition.w = Out.Position.z;
 	Out.TexCoords.xy = In.TexCoords;
 	Out.Normal_Light = EyeVector;
@@ -422,7 +422,7 @@ float3 _PSGetOvercastColor(in float4 Color, in VERTEX_OUTPUT In)
 	// Value used to determine equivalent grayscale color.
 	const float3 LumCoeff = float3(0.2125, 0.7154, 0.0721);
 
-	float intensity = dot(Color, LumCoeff);
+	float intensity = dot((float3)Color, LumCoeff);
 	return lerp(intensity, Color.rgb, 0.8) * 0.5;
 }
 
@@ -477,7 +477,7 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	if (ShaderModel3) _PSSceneryFade(Color, In);
@@ -513,7 +513,7 @@ float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -534,9 +534,9 @@ float4 PSTerrain(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Overlay image for terrain.
-	litColor.rgb *= tex2D(Overlay, In.TexCoords.xy * OverlayScale) * 2;
+	litColor.rgb *= (float3)tex2D(Overlay, In.TexCoords.xy * OverlayScale) * 2;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -569,7 +569,7 @@ float4 PSDarkShade(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -591,7 +591,7 @@ float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= HalfNightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -609,7 +609,7 @@ float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
 	// No overcast effect for full-bright.
 	// No night-time effect for full-bright.
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, Color, In);
+	_PSApplyHeadlights(litColor, (float3)Color, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);

--- a/Source/RunActivity/Content/SceneryShader.fx
+++ b/Source/RunActivity/Content/SceneryShader.fx
@@ -170,7 +170,7 @@ void _VSNormalProjection(in VERTEX_INPUT In, inout VERTEX_OUTPUT Out)
 void _VSSignalProjection(uniform bool Glow, in VERTEX_INPUT_SIGNAL In, inout VERTEX_OUTPUT Out)
 {
 	// Project position, normal and copy texture coords
-	float3 relPos = (float3)mul(In.Position, World) - ViewerPos;
+	float3 relPos = mul(In.Position, World).xyz - ViewerPos;
 	// Position 1.5cm in front of signal.
 	In.Position.z += 0.015;
 	if (Glow) {
@@ -295,7 +295,7 @@ VERTEX_OUTPUT VSForest(in VERTEX_INPUT_FOREST In)
 	float3 upVector = float3(0, -1, 0); // This constant is also defined in Shareds.cs
 
 	// Move the vertex left/right/up/down based on the normal values (tree size).
-	float3 newPosition = (float3)In.Position;
+	float3 newPosition = In.Position.xyz;
 	newPosition += (In.TexCoords.x - 0.5f) * SideVector * In.Normal.x;
 	newPosition += (In.TexCoords.y - 1.0f) * upVector * In.Normal.y;
 	In.Position = float4(newPosition, 1);
@@ -422,7 +422,7 @@ float3 _PSGetOvercastColor(in float4 Color, in VERTEX_OUTPUT In)
 	// Value used to determine equivalent grayscale color.
 	const float3 LumCoeff = float3(0.2125, 0.7154, 0.0721);
 
-	float intensity = dot((float3)Color, LumCoeff);
+	float intensity = dot(Color.rgb, LumCoeff);
 	return lerp(intensity, Color.rgb, 0.8) * 0.5;
 }
 
@@ -477,7 +477,7 @@ float4 PSImage(uniform bool ShaderModel3, uniform bool ClampTexCoords, in VERTEX
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	if (ShaderModel3) _PSSceneryFade(Color, In);
@@ -513,7 +513,7 @@ float4 PSVegetation(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -534,9 +534,9 @@ float4 PSTerrain(uniform bool ShaderModel3, in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Overlay image for terrain.
-	litColor.rgb *= (float3)tex2D(Overlay, In.TexCoords.xy * OverlayScale) * 2;
+	litColor.rgb *= tex2D(Overlay, In.TexCoords.xy * OverlayScale).rgb * 2;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -569,7 +569,7 @@ float4 PSDarkShade(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= NightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -591,7 +591,7 @@ float4 PSHalfBright(in VERTEX_OUTPUT In) : COLOR0
 	// Night-time darkens everything, except night-time textures.
 	litColor *= HalfNightColorModifier;
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);
@@ -609,7 +609,7 @@ float4 PSFullBright(in VERTEX_OUTPUT In) : COLOR0
 	// No overcast effect for full-bright.
 	// No night-time effect for full-bright.
 	// Headlights effect use original Color.
-	_PSApplyHeadlights(litColor, (float3)Color, In);
+	_PSApplyHeadlights(litColor, Color.rgb, In);
 	// And fogging is last.
 	_PSApplyFog(litColor, In);
 	_PSSceneryFade(Color, In);

--- a/Source/RunActivity/Content/ShadowMap.fx
+++ b/Source/RunActivity/Content/ShadowMap.fx
@@ -92,7 +92,7 @@ VERTEX_OUTPUT VSShadowMap(in VERTEX_INPUT In)
 
 	if (determinant(In.Instance) != 0) {
 		In.Position = mul(In.Position, transpose(In.Instance));
-		In.Normal = mul(In.Normal, transpose(In.Instance));
+		In.Normal = mul(In.Normal, (float3x3)transpose(In.Instance));
 	}
 
 	Out.Position = mul(In.Position, WorldViewProjection);
@@ -110,7 +110,7 @@ VERTEX_OUTPUT VSShadowMapForest(in VERTEX_INPUT_FOREST In)
 	float3 upVector = float3(0, -1, 0);
 
 	// Move the vertex left/right/up/down based on the normal values (tree size).
-	float3 newPosition = In.Position;
+	float3 newPosition = (float3)In.Position;
 	newPosition += (In.TexCoord.x - 0.5f) * SideVector * In.Normal.x;
 	newPosition += (In.TexCoord.y - 1.0f) * upVector * In.Normal.y;
 	In.Position = float4(newPosition, 1);

--- a/Source/RunActivity/Content/ShadowMap.fx
+++ b/Source/RunActivity/Content/ShadowMap.fx
@@ -110,7 +110,7 @@ VERTEX_OUTPUT VSShadowMapForest(in VERTEX_INPUT_FOREST In)
 	float3 upVector = float3(0, -1, 0);
 
 	// Move the vertex left/right/up/down based on the normal values (tree size).
-	float3 newPosition = (float3)In.Position;
+	float3 newPosition = In.Position.xyz;
 	newPosition += (In.TexCoord.x - 0.5f) * SideVector * In.Normal.x;
 	newPosition += (In.TexCoord.y - 1.0f) * upVector * In.Normal.y;
 	In.Position = float4(newPosition, 1);


### PR DESCRIPTION
This PR makes some HLSL casts explicit so that Monogame doesn't fill the log with compilation warnings. Many of these fixes are taken from the shader code that dennisat [submitted](http://www.elvastower.com/forums/index.php?/topic/30924-going-beyond-the-4-gb-of-memory/page__st__90__p__228366#entry228366) to the NewYear fork.

Do double-check my changes as I am unfamiliar with the HLSL language. In my testing, I have not been able to spot any visual differences or glitches.