### PR TITLE
Track Viewer fixes

### DIFF
--- a/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
+++ b/Source/Contrib/TrackViewer/Drawing/BasicShapes.cs
@@ -140,7 +140,7 @@ namespace ORTS.TrackViewer.Drawing
                 pixels[i] = ColorWithHighlights.Highlighted(pixels[i], offset);
             }
 
-            Texture2D outTexture = new Texture2D(graphicsDevice, texture.Width, texture.Height, true, SurfaceFormat.Color);
+            Texture2D outTexture = new Texture2D(graphicsDevice, texture.Width, texture.Height, mipmap: false, SurfaceFormat.Color);
             outTexture.SetData<Color>(pixels);
             return outTexture;
         }
@@ -154,7 +154,7 @@ namespace ORTS.TrackViewer.Drawing
         private static Texture2D CreateCircleTexture(GraphicsDevice graphicsDevice, int outerRadius)
         {
             int radius = (outerRadius - 2)/2; // So circle doesn't go out of bounds
-            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius,  true, SurfaceFormat.Color);
+            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, mipmap: false, SurfaceFormat.Color);
 
             Color[] data = new Color[outerRadius * outerRadius];
 
@@ -187,7 +187,7 @@ namespace ORTS.TrackViewer.Drawing
         private static Texture2D CreateDiscTexture(GraphicsDevice graphicsDevice, int outerRadius)
         {
             int radius = (outerRadius - 1) / 2;
-            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, true, SurfaceFormat.Color);
+            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, mipmap: false, SurfaceFormat.Color);
 
             Color[] data = new Color[outerRadius * outerRadius];
 
@@ -221,7 +221,7 @@ namespace ORTS.TrackViewer.Drawing
         {
             int radius = (outerRadius - 1) / 2;
             int innerRadius = (2 * radius) / 3;
-            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, true, SurfaceFormat.Color);
+            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, mipmap: false, SurfaceFormat.Color);
 
             Color[] data = new Color[outerRadius * outerRadius];
 
@@ -257,7 +257,7 @@ namespace ORTS.TrackViewer.Drawing
             int radius = (outerRadius - 1) / 2;
             int innerRadius = (3 * radius) / 4;
             int crossWidth = 5;
-            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, true, SurfaceFormat.Color);
+            Texture2D texture = new Texture2D(graphicsDevice, outerRadius, outerRadius, mipmap: false, SurfaceFormat.Color);
 
             Color[] data = new Color[outerRadius * outerRadius];
 

--- a/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
@@ -985,7 +985,7 @@ namespace ORTS.TrackViewer.Drawing
         {
             int width = renderTarget.Width;
             int height = renderTarget.Height;
-            var scaledTexture = new Texture2D(device, width, height, true, SurfaceFormat.Color);
+            var scaledTexture = new Texture2D(device, width, height, mipmap: false, SurfaceFormat.Color);
             Color[] data = GetColorDataArray(width * height);
             renderTarget.GetData<Color>(data);
             scaledTexture.SetData(data);

--- a/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
@@ -85,6 +85,11 @@ namespace ORTS.TrackViewer.Drawing
         //basic graphics
         private GraphicsDevice device;
         private BasicEffect basicEffect;
+        private static readonly SamplerState samplerState = new SamplerState
+        {
+            AddressU = TextureAddressMode.Wrap,
+            AddressV = TextureAddressMode.Wrap,
+        };
 
         //Managin textures
         private TerrainTextureManager textureManager;
@@ -401,8 +406,7 @@ namespace ORTS.TrackViewer.Drawing
         {
             UpdateCamera(drawArea);
 
-            device.SamplerStates[0].AddressU = TextureAddressMode.Wrap;
-            device.SamplerStates[0].AddressV = TextureAddressMode.Wrap;
+            device.SamplerStates[0] = samplerState;
 
             foreach (string textureName in vertexBuffers.Keys)
             {

--- a/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
+++ b/Source/Contrib/TrackViewer/Drawing/DrawTerrain.cs
@@ -85,11 +85,6 @@ namespace ORTS.TrackViewer.Drawing
         //basic graphics
         private GraphicsDevice device;
         private BasicEffect basicEffect;
-        private static readonly SamplerState samplerState = new SamplerState
-        {
-            AddressU = TextureAddressMode.Wrap,
-            AddressV = TextureAddressMode.Wrap,
-        };
 
         //Managin textures
         private TerrainTextureManager textureManager;
@@ -406,7 +401,7 @@ namespace ORTS.TrackViewer.Drawing
         {
             UpdateCamera(drawArea);
 
-            device.SamplerStates[0] = samplerState;
+            device.SamplerStates[0] = SamplerState.LinearWrap;
 
             foreach (string textureName in vertexBuffers.Keys)
             {


### PR DESCRIPTION
- The Track Viewer crashes when rendering a route because the code tries to modify a default SamplerState object. This was first [reported](http://www.elvastower.com/forums/index.php?/topic/34485-cant-start-a-route-in-trackviewer/) by eugenR at Elvas Tower.
- Mipmapping must be turned off for basic shapes and scaled terrain for them to display.