### PR TITLE
Fix Spanish manual build

### DIFF
--- a/Source/Menu/Menu.csproj
+++ b/Source/Menu/Menu.csproj
@@ -200,13 +200,6 @@
     </PreBuildEvent>
     <PostBuildEvent>echo $Revision: 000 $&gt;Revision.txt
 date /t&gt;&gt;Revision.txt
-time /t&gt;&gt;Revision.txt
-
-REM Copy Spanish manual until we can make its RST files part of the build.
-CD ..\
-IF EXIST "Program\Documentation\es" RMDIR "Program\Documentation\es" /S /Q
-IF NOT EXIST "Program\Documentation\es" MKDIR "Program\Documentation\es"
-COPY "Source\Documentation\Manual\es\Manual.pdf" "Program\Documentation\es\"
-</PostBuildEvent>
+time /t&gt;&gt;Revision.txt</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The current process has continued to break the Unstable Version documentation for too long, and also does the copy in an odd place (should be in `Build.cmd`).

This PR fixes that (currently draft as only partially fixed).